### PR TITLE
Fix screenshot URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ _Disclaimer: This website does not collect or store any kind of information abou
 
 # Screenshot
 
-![screenshot](https://github.com/what-name/what-name.github.io/edit/master/preview.png?raw=true)
+![screenshot](preview.png)

--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ _Disclaimer: This website does not collect or store any kind of information abou
 
 # Screenshot
 
-![screenshot](https://github.com/what-name/howMuchHaveYouLived/blob/master/preview.png?raw=true)
+![screenshot](https://github.com/what-name/what-name.github.io/edit/master/preview.png?raw=true)


### PR DESCRIPTION
Changed the screenshot's URL from a hardcoded https link to a dynamic one referring to the a file inside the repo.